### PR TITLE
Fix sky ViewportTexture path

### DIFF
--- a/addons/joyeux.dynamic_sky/src/DynamicDayNight.gd
+++ b/addons/joyeux.dynamic_sky/src/DynamicDayNight.gd
@@ -116,7 +116,7 @@ func _ready() -> void:
 func retry_draw() -> void:
 	var Sky : ViewportTexture = ViewportTexture.new()
 	Sky.resource_local_to_scene = true
-	Sky.viewport_path = "Sky"
+	Sky.viewport_path = $Sky.get_path()
 	Sky.flags = Texture.FLAG_FILTER
 	environment.background_sky.panorama = Sky
 	environment.background_sky.radiance_size = 3


### PR DESCRIPTION
I have problem instancing this environment into my scene, so this change picks absolute path regardless where's addon located


On a side note, I don't know where this comes from, which gives error on fresh install
`	EnvironmentBlender.register_main_env(self)`
